### PR TITLE
Enable automated testing with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-script: make && make test
+script: make ncpus=8 && make test
 language: c
 compiler:
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ addons:
       - libevent-dev
       - curl
       - ruby
+      - valgrind

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+script: make && make test
 language: c
 compiler:
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: c
+compiler:
+  - clang
+  - gcc
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,8 @@
 language: c
+addons:
+  apt:
+    packages:
+      - cmake
+      - libevent-dev
+      - curl
+      - ruby

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 libnlutils
 ==========
 
-This project contains well-tested basic utility functions and data structures
+This project contains [well-tested ![Build Status](https://travis-ci.org/nitrogenlogic/nlutils.svg?branch=master)](https://travis-ci.org/nitrogenlogic/nlutils) basic utility functions and data structures
 for Nitrogen Logic C programs.  It also contains tools for cross-compiling code
 and building firmware images for Nitrogen Logic controllers.
 


### PR DESCRIPTION
This PR adds Travis CI configuration for automated testing of nlutils.

https://travis-ci.org/nitrogenlogic/nlutils