### PR TITLE
Add a function for parsing ANSI terminal color escape sequences

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,21 @@ jobs:
         run: make
       - name: Run tests
         run: bundle exec make test
+  test-debug:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Install apt deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install cmake libevent-dev curl ruby valgrind clang gcc build-essential
+      - name: Install gem deps
+        run: bundle install
+      - name: Compile (debug build)
+        run: make debug
+      - name: Run tests (debug build)
+        run: bundle exec make test-debug

--- a/include/nlutils.h
+++ b/include/nlutils.h
@@ -141,6 +141,7 @@ extern const char * const nlutils_version;
 #include "fifo.h"
 #include "url_req.h"
 #include "debug.h"
+#include "term.h"
 
 #ifdef __cplusplus
 }

--- a/include/term.h
+++ b/include/term.h
@@ -1,0 +1,104 @@
+/*
+ * Terminal-related utility functions, such as ANSI color escape parsing.
+ *
+ * Written in part as an exercise.  There are probably off-the-shelf tools that
+ * one should use instead.
+ *
+ * Do not include this file directly.  Instead, include nlutils.h.
+ *
+ * Copyright (C)2023 Mike Bourgeous, licensed under AGPLv3.
+ */
+#ifndef NLUTILS_TERM_H_
+#define NLUTILS_TERM_H_
+
+#include <stdint.h>
+
+/*
+ * The type or origin of a color stored in struct nl_term_color.  This is
+ * determined by the escape sequence that generated the color.
+ */
+enum nl_term_color_type {
+	// A default color set by 0m, 39m, or 49m, that does not match any of the standard colors
+	NL_TERM_COLOR_DEFAULT = -1,
+
+	// A standard color set by 30..37m or 40..47m
+	NL_TERM_COLOR_STANDARD = 0,
+
+	// An Xterm-256 color set by 38;5;Xm
+	NL_TERM_COLOR_256 = 1,
+
+	// A 24-bit RGB color set by 38;2;R;G;Bm
+	NL_TERM_COLOR_RGB = 2,
+};
+
+/*
+ * Represents a foreground or background color, including information on
+ * whether it originated as a standard ANSI color or an Xterm 8-bit color.
+ *
+ * Bold/intensity is represented in struct nl_term_state, though Xterm colors 8
+ * through 15 also represent intense colors.
+ */
+struct nl_term_color {
+	// 24-bit renderable color (always set, regardless of whether 24-bit color was used)
+	// Foreground: \e[38;2;R;G;Bm
+	// Background: \e[48;2;R;G;Bm
+	uint8_t r, g, b;
+
+	// Xterm 256 color index, if current color was set using standard or xterm 256 color, otherwise 0
+	// Foreground: \e[38;5;Xm
+	// Background: \e[48;5;Xm
+	uint8_t xterm256;
+
+	// ANSI color index, if current color was set using standard colors, otherwise 0
+	// Foreground: \e[30..37m
+	// Background: \e[40..47m
+	uint8_t ansi:3;
+
+	// The source of this color.
+	enum nl_term_color_type color_type;
+};
+
+/*
+ * Represents the font intensity (bold/intense, faint, or normal).
+ * Bold: \e[1m
+ * Faint: \e[2m
+ * Normal: \e[22m
+ */
+enum nl_term_intensity {
+	NL_TERM_NORMAL = 0,
+	NL_TERM_INTENSE = 1,
+	NL_TERM_BOLD = 1,
+	NL_TERM_FAINT = 2,
+};
+
+/*
+ * Represents an ANSI color state.  You may use nl_init_term_state() or the
+ * nl_default_term_state constant to set typical default values.
+ */
+struct nl_term_state {
+	// Foreground color
+	struct nl_term_color fg;
+
+	// Background color
+	struct nl_term_color bg;
+
+	// Normal, bold, or faint
+	enum nl_term_intensity intensity;
+
+	// Font style flags
+	unsigned int italic:1;
+	unsigned int underline:1;
+	unsigned int blink:1;
+	unsigned int reverse:1;
+	unsigned int strikethrough:1;
+};
+
+/* Default terminal state, for use as an initializer. */
+extern const struct nl_term_state nl_default_term_state;
+
+/*
+ * Sets default state values on the given terminal state struct.
+ */
+void nl_init_term_state(struct nl_term_state *s);
+
+#endif /* NLUTILS_TERM_H_ */

--- a/include/term.h
+++ b/include/term.h
@@ -129,6 +129,8 @@ extern const struct nl_term_color nl_term_faint_foreground;
  */
 #define NL_TERM_BACKGROUND_INITIALIZER { \
 	.r = 16, .g = 16, .b = 16, \
+	.xterm256 = 0, \
+	.ansi = 0, \
 	.color_type = NL_TERM_COLOR_DEFAULT, \
 }
 

--- a/include/term.h
+++ b/include/term.h
@@ -25,7 +25,7 @@ enum nl_term_color_type {
 	NL_TERM_COLOR_STANDARD = 0,
 
 	// An Xterm-256 color set by 38;5;Xm
-	NL_TERM_COLOR_256 = 1,
+	NL_TERM_COLOR_XTERM256 = 1,
 
 	// A 24-bit RGB color set by 38;2;R;G;Bm
 	NL_TERM_COLOR_RGB = 2,
@@ -97,8 +97,75 @@ struct nl_term_state {
 extern const struct nl_term_state nl_default_term_state;
 
 /*
+ * The default foreground color if no explicit color is set and neither bold
+ * nor faint intensity is active.
+ */
+extern const struct nl_term_color nl_term_default_foreground;
+
+/*
+ * The default bold foreground color if no explicit color is set but color
+ * intensity is set to bold.
+ */
+extern const struct nl_term_color nl_term_bold_foreground;
+
+/*
+ * The default faint foreground color if no explicit color is set, but color
+ * intensity is set to faint.
+ */
+extern const struct nl_term_color nl_term_faint_foreground;
+
+/*
+ * Struct initializer with default foreground color for struct nl_term_state.
+ */
+#define NL_TERM_FOREGROUND_INITIALIZER { \
+	.r = 158, .g = 158, .b = 158, \
+	.xterm256 = 7, \
+	.ansi = 7, \
+	.color_type = NL_TERM_COLOR_DEFAULT, \
+}
+
+/*
+ * Struct initializer with default background color for struct nl_term_state.
+ */
+#define NL_TERM_BACKGROUND_INITIALIZER { \
+	.r = 16, .g = 16, .b = 16, \
+	.color_type = NL_TERM_COLOR_DEFAULT, \
+}
+
+/*
+ * Default values for struct nl_term_state.
+ * Use as nl_term_state s = NL_TERM_STATE_INITIALIZER;
+ */
+#define NL_TERM_STATE_INITIALIZER {\
+	.fg = NL_TERM_FOREGROUND_INITIALIZER, \
+	.bg = NL_TERM_BACKGROUND_INITIALIZER, \
+	.intensity = NL_TERM_NORMAL, \
+	.italic = 0, \
+	.underline = 0, \
+	.blink = 0, \
+	.reverse = 0, \
+	.strikethrough = 0, \
+}
+
+/*
  * Sets default state values on the given terminal state struct.
  */
 void nl_init_term_state(struct nl_term_state *s);
+
+/*
+ * Parses an ANSI color sequence at the start of the given string.  Returns the
+ * number of characters consumed, 0 if the sequence could not be parsed as an
+ * ANSI color (thus no characters consumed), or -1 on error.
+ *
+ * The given terminal state will be updated with the changes described by the
+ * escape sequence in s.  The state is only updated if a full, valid escape
+ * sequence can be parsed.
+ *
+ * Example valid string prefixes (anything after the m is ignored):
+ *     "\e[1m" -- turns on bold, returns 4
+ *     "\e[35m" -- sets a purple/magenta foreground, returns 5
+ *     "\e[38;2;128;128;128m" -- sets a dark gray 24-bit foreground, returns 19
+ */
+int nl_term_parse_ansi_color(char *s, struct nl_term_state *state);
 
 #endif /* NLUTILS_TERM_H_ */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(nlutils SHARED escape.c exec.c nlutils.c sha1.c
 	str.c stream.c net.c log.c thread.c variant.c kvp.c debug.c
-	url.c fifo.c hash.c url_req.c mem.c nl_time.c inline_defs.c)
+	url.c fifo.c hash.c url_req.c mem.c nl_time.c term.c
+	inline_defs.c)
 
 find_library(LIBEVENT_CORE_LIBRARY event_core HINTS /usr/local/lib /usr/lib /usr/lib/arm-linux-gnueabi /usr/lib/x86_64-linux-gnu)
 target_link_libraries(nlutils dl rt m ${LIBEVENT_CORE_LIBRARY})

--- a/src/term.c
+++ b/src/term.c
@@ -532,6 +532,8 @@ int nl_term_parse_ansi_color(char *s, struct nl_term_state *state)
 					parse_color = nl_term_xterm_grays[n - 232];
 				}
 
+				parse_color.color_type = NL_TERM_COLOR_XTERM256;
+
 				set_target_color(&new_state, color_target, &parse_color);
 
 				ps = EXPECT_SEMICOLON;

--- a/src/term.c
+++ b/src/term.c
@@ -125,6 +125,17 @@ const struct nl_term_color nl_term_xterm_grays[32] = {
 	{ 0xee, 0xee, 0xee, 255, 0, NL_TERM_COLOR_XTERM256 },
 };
 
+// Xterm jumps from 0 to 95, then uses increments of 40, for the 6 values
+// for R, G, or B in its 216-color cube for 256-color mode.
+static const uint8_t xterm_rgb_values[6] = {
+	0,
+	95,
+	135,
+	175,
+	215,
+	255
+};
+
 /* Default terminal state, for use as an initializer. */
 const struct nl_term_state nl_default_term_state = NL_TERM_STATE_INITIALIZER;
 
@@ -520,9 +531,9 @@ int nl_term_parse_ansi_color(char *s, struct nl_term_state *state)
 				} else if (n < 232) {
 					uint8_t rgb = n - 16;
 					parse_color = (struct nl_term_color){
-						.r = rgb / 36,
-						.g = (rgb / 6) % 6,
-						.b = rgb % 6,
+						.r = xterm_rgb_values[rgb / 36],
+						.g = xterm_rgb_values[(rgb / 6) % 6],
+						.b = xterm_rgb_values[rgb % 6],
 
 						.xterm256 = n,
 

--- a/src/term.c
+++ b/src/term.c
@@ -292,7 +292,7 @@ int nl_term_parse_ansi_color(char *s, struct nl_term_state *state)
 	unsigned long n;
 	unsigned int loops = 0;
 	while(*ptr) {
-		DEBUG_OUT("Color parsing offset %td ('%c'), current state %d, next state %d\n", ptr - s, *ptr, ps, next_ps);
+		DEBUG_OUT("Color parsing offset %td ('%.4s...'), current state %d, next state %d\n", ptr - s, ptr, ps, next_ps);
 
 		if (ptr - s > MAX_COLOR_PARSE_LENGTH) {
 			DEBUG_OUT("Maximum ANSI color sequence length of %d exceeded\n", MAX_COLOR_PARSE_LENGTH);
@@ -313,6 +313,8 @@ int nl_term_parse_ansi_color(char *s, struct nl_term_state *state)
 
 		switch(ps) {
 			case EXPECT_SEMICOLON:
+				DEBUG_OUT("Looking for a semicolon.\n");
+
 				if (*ptr != ';') {
 					// This should have been a semicolon
 					DEBUG_OUT("Expected a semicolon, saw '%c'.\n", *ptr);
@@ -325,7 +327,9 @@ int nl_term_parse_ansi_color(char *s, struct nl_term_state *state)
 				break;
 
 			case EXPECT_CONTROL:
-				next_ps = EXPECT_SEMICOLON;
+				DEBUG_OUT("Looking for a control code.\n");
+
+				next_ps = EXPECT_CONTROL;
 
 				n = strtoul(ptr, &endptr, 10);
 				if (endptr == NULL || endptr == ptr) {
@@ -337,101 +341,124 @@ int nl_term_parse_ansi_color(char *s, struct nl_term_state *state)
 				// I bet that some parsers and the original hardware just use the ones digit as a bit index to set or clear for 1..9 and 21..29
 				switch(n) {
 					case 0:
+						DEBUG_OUT("Code 0, reset state\n");
 						new_state = nl_default_term_state;
 						break;
 
 					case 1:
+						DEBUG_OUT("Code 1, turn on bold\n");
 						new_state.intensity = NL_TERM_INTENSE;
 						set_color_intensity(&new_state);
 						break;
 
 					case 2:
+						DEBUG_OUT("Code 2, turn on faint\n");
 						new_state.intensity = NL_TERM_FAINT;
 						set_color_intensity(&new_state);
 						break;
 
 					case 3:
+						DEBUG_OUT("Code 3, turn on italic\n");
 						new_state.italic = 1;
 						break;
 
 					case 4:
+						DEBUG_OUT("Code 4, turn on underline\n");
 						new_state.underline = 1;
 						break;
 
 					case 5:
+						DEBUG_OUT("Code 5, turn on blink\n");
 						new_state.blink = 1;
 						break;
 
 					case 7:
+						DEBUG_OUT("Code 7, turn on reverse\n");
 						new_state.reverse = 1;
 						break;
 
 					case 9:
+						DEBUG_OUT("Code 9, turn on strikethrough\n");
 						new_state.strikethrough = 1;
 						break;
 
 					case 22:
+						DEBUG_OUT("Code 22, turn off bold or faint\n");
 						new_state.intensity = NL_TERM_NORMAL;
 						set_color_intensity(&new_state);
 						break;
 
 					case 23:
+						DEBUG_OUT("Code 23, turn off italic\n");
 						new_state.italic = 0;
 						break;
 
 					case 24:
+						DEBUG_OUT("Code 24, turn off underline\n");
 						new_state.underline = 0;
 						break;
 
 					case 25:
+						DEBUG_OUT("Code 25, turn off blink\n");
 						new_state.blink = 0;
 						break;
 
 					case 27:
+						DEBUG_OUT("Code 27, turn off reverse\n");
 						new_state.reverse = 0;
 						break;
 
 					case 29:
+						DEBUG_OUT("Code 29, turn off strikethrough\n");
 						new_state.strikethrough = 0;
 						break;
 
 					case 38:
+						DEBUG_OUT("Code 38, special foreground color\n");
 						ps = EXPECT_SEMICOLON;
 						next_ps = EXPECT_2_OR_5;
 						color_target = FOREGROUND_COLOR;
 						break;
 
 					case 39:
+						DEBUG_OUT("Code 39, reset foreground color\n");
 						new_state.fg = nl_term_default_foreground;
 						set_color_intensity(&new_state);
 						break;
 
 					case 48:
+						DEBUG_OUT("Code 48, special background color\n");
 						ps = EXPECT_SEMICOLON;
 						next_ps = EXPECT_2_OR_5;
-						color_target = FOREGROUND_COLOR;
+						color_target = BACKGROUND_COLOR;
 						break;
 
 					case 49:
+						DEBUG_OUT("Code 49, reset background color\n");
 						new_state.bg = nl_term_default_background;
 						break;
 
 					default:
 						// Handle standard colors, ignore unsupported values
 						if (n >= 30 && n <= 37) {
+							DEBUG_OUT("Code %lu, set foreground color %lu\n", n, n - 30);
 							new_state.fg = nl_term_standard_colors[new_state.intensity][n - 30];
 						} else if (n >= 40 && n <= 47) {
-							new_state.bg = nl_term_standard_colors[NL_TERM_NORMAL][n - 30];
+							DEBUG_OUT("Code %lu, set background color %lu\n", n, n - 40);
+							new_state.bg = nl_term_standard_colors[NL_TERM_NORMAL][n - 40];
+						} else {
+							DEBUG_OUT("Unknown code %lu, ignoring.\n", n);
 						}
 
 						break;
 				}
 
 				ps = EXPECT_SEMICOLON;
-				next_ps = EXPECT_CONTROL;
 				break;
 
 			case EXPECT_2_OR_5:
+				DEBUG_OUT("Looking for 2 for RGB, or 5 for xterm-256.\n");
+
 				// If we see 2, expect a 24-bit color.  If we see 5, expect an xterm color.
 				// For other values, xterm ignores them, while konsole resets the color and treats the
 				// value as a standard control code.  Let's do what xterm does.
@@ -444,30 +471,35 @@ int nl_term_parse_ansi_color(char *s, struct nl_term_state *state)
 
 				switch(n) {
 					case 2:
-						// Xterm 256 color
-						next_ps = EXPECT_XTERM_256;
-						parse_color.ansi = 0;
-						parse_color.color_type = NL_TERM_COLOR_XTERM256;
-						break;
-
-					case 5:
 						// RGB color
+						DEBUG_OUT("Code 2, RGB.\n");
 						next_ps = EXPECT_RED;
 						parse_color.xterm256 = 0;
 						parse_color.ansi = 0;
 						parse_color.color_type = NL_TERM_COLOR_RGB;
 						break;
 
+					case 5:
+						// Xterm 256 color
+						DEBUG_OUT("Code 5, xterm-256.\n");
+						next_ps = EXPECT_XTERM_256;
+						parse_color.ansi = 0;
+						parse_color.color_type = NL_TERM_COLOR_XTERM256;
+						break;
+
 					default:
 						// Ignore anything else like xterm seems to do
+						DEBUG_OUT("Ignoring unexpected color type %lu\n", n);
 						next_ps = EXPECT_CONTROL;
 						break;
 				}
-				
+
 				ps = EXPECT_SEMICOLON;
 				break;
 
 			case EXPECT_XTERM_256:
+				DEBUG_OUT("Looking for an xterm-256color color index\n");
+
 				n = strtoul(ptr, &endptr, 10);
 				if (endptr == NULL || endptr == ptr) {
 					DEBUG_OUT("Did not find a number when looking for an 8-bit xterm 256-color color index.\n");
@@ -505,6 +537,13 @@ int nl_term_parse_ansi_color(char *s, struct nl_term_state *state)
 			case EXPECT_RED:
 			case EXPECT_GREEN:
 			case EXPECT_BLUE:
+				DEBUG_OUT("Looking for an RGB color component: %s\n",
+						ps == EXPECT_RED ? "red" :
+						ps == EXPECT_GREEN ? "green" :
+						ps == EXPECT_BLUE ? "blue" :
+						"BUG"
+						);
+
 				n = strtoul(ptr, &endptr, 10);
 				if (endptr == NULL || endptr == ptr) {
 					DEBUG_OUT("Did not find a number when looking for an 8-bit RGB color component.\n");

--- a/src/term.c
+++ b/src/term.c
@@ -1,0 +1,381 @@
+/*
+ * Terminal-related utility functions, such as ANSI color escape parsing.
+ *
+ * Written in part as an exercise.  There are probably off-the-shelf tools that
+ * one should use instead.
+ *
+ * Copyright (C)2023 Mike Bourgeous, licensed under AGPLv3.
+ */
+
+#include <ctype.h>
+
+#include "nlutils.h"
+
+/*
+ * The default foreground color if no explicit color is set.
+ */
+const struct nl_term_color nl_term_default_foreground = {
+	.r = 158, .g = 158, .b = 158,
+	.color_type = NL_TERM_COLOR_DEFAULT,
+};
+
+/*
+ * The default bold foreground color if no explicit color is set but color
+ * intensity is set to bold.
+ */
+const struct nl_term_color nl_term_bold_foreground = {
+	.r = 234, .g = 234, .b = 234,
+	.color_type = NL_TERM_COLOR_DEFAULT,
+};
+
+/*
+ * The default bold foreground color if no explicit color is set but color
+ * intensity is set to faint.
+ */
+const struct nl_term_color nl_term_faint_foreground = {
+	.r = 234, .g = 234, .b = 234,
+	.color_type = NL_TERM_COLOR_DEFAULT,
+};
+
+/*
+ * The default background color if no explicit color is set.
+ */
+const struct nl_term_color nl_term_default_background = {
+	.r = 16, .g = 16, .b = 16,
+	.color_type = NL_TERM_COLOR_DEFAULT,
+};
+
+/*
+ * Standard terminal colors in normal, bold, and faint intensities (0 through
+ * 7), plus default colors for foreground (8) and background (9).
+ */
+const struct nl_term_color nl_term_standard_colors[3][10] = {
+	[ NL_TERM_NORMAL ] = {
+		[0] = {  36,  36,  36, 0, 0 },
+		[1] = { 204,  66,  66, 1, 1 },
+		[2] = { 104, 154,  51, 2, 2 },
+		[3] = { 196, 165,  42, 3, 3 },
+		[4] = {  61, 107, 164, 4, 4 },
+		[5] = { 116,  80, 123, 5, 5 },
+		[6] = {  63, 154, 154, 6, 6 },
+		[7] = { 158, 158, 158, 7, 7 },
+
+		// Default colors (foreground, background)
+		[8] = nl_term_default_foreground,
+		[9] = nl_term_default_background,
+	},
+	[ NL_TERM_BOLD ] = {
+		[0] = {  70,  70,  70,  8, 0 },
+		[1] = { 225,  70,  70,  9, 1 },
+		[2] = { 138, 196,  81, 10, 2 },
+		[3] = { 205, 189,  83, 11, 3 },
+		[4] = {  85, 146, 207, 12, 4 },
+		[5] = { 173, 115, 167, 13, 5 },
+		[6] = {  78, 190, 190, 14, 6 },
+		[7] = { 234, 234, 234, 15, 7 },
+
+		[8] = nl_term_bold_foreground,
+		[9] = nl_term_default_background,
+	},
+	[ NL_TERM_FAINT ] = {
+		[0] = {  24,  24,  24, 0, 0 },
+		[1] = { 140,  41,  41, 1, 1 },
+		[2] = {  70, 100,  41, 2, 2 },
+		[3] = { 100,  87,  40, 3, 3 },
+		[4] = {  39,  78, 125, 4, 4 },
+		[5] = {  95,  65, 100, 5, 5 },
+		[6] = {  35,  80,  80, 6, 6 },
+		[7] = {  80,  80,  80, 7, 7 },
+
+		[8] = nl_term_bold_foreground,
+		[9] = nl_term_default_background,
+	},
+};
+
+/* Default terminal state, for use as an initializer. */
+const struct nl_term_state nl_default_term_state = {
+	.fg = nl_term_default_foreground,
+	.bg = nl_term_default_background,
+
+	.intensity = NL_TERM_NORMAL,
+
+	.italic = 0,
+	.underline = 0,
+	.strikethrough = 0,
+};
+
+/*
+ * Sets default state values on the given terminal state struct.
+ */
+void nl_init_term_state(struct nl_term_state *s)
+{
+	*s = nl_default_term_state;
+}
+
+static void make_color_faint(struct nl_term_color *c)
+{
+	switch(c->color_type) {
+		case NL_TERM_COLOR_DEFAULT:
+			*c = nl_term_faint_foreground;
+			break;
+
+		case NL_TERM_COLOR_STANDARD:
+			*c = nl_term_colors[NL_TERM_FAINT][c->ansi];
+			break;
+
+		case NL_TERM_COLOR_256:
+			// Xterm-256 colors 0..15 are standard and bold colors
+			if (c->xterm256 < 8) {
+				c = nl_term_colors[NL_TERM_FAINT][c->xterm256];
+			} else if (c->xterm256 < 16) {
+				c = nl_term_colors[NL_TERM_FAINT][c->xterm256 - 8];
+			}
+			break;
+
+		default:
+			// Do nothing for RGB colors
+			break;
+	}
+}
+
+static void make_color_intense(struct nl_term_color *c)
+{
+	switch(c->color_type) {
+		case NL_TERM_COLOR_DEFAULT:
+			*c = nl_term_bold_foreground;
+			break;
+
+		case NL_TERM_COLOR_STANDARD:
+			*c = nl_term_colors[NL_TERM_INTENSE][c->ansi];
+			break;
+
+		case NL_TERM_COLOR_256:
+			if (c->xterm256 < 8) {
+				c = nl_term_colors[NL_TERM_INTENSE][c->xterm256];
+			}
+			break;
+
+		default:
+			// Do nothing for RGB colors
+			break;
+	}
+}
+
+static void make_color_normal(struct nl_term_color *c)
+{
+	switch(c->color_type) {
+		case NL_TERM_COLOR_DEFAULT:
+			*c = nl_term_default_foreground;
+			break;
+
+		case NL_TERM_COLOR_STANDARD:
+			*c = nl_term_colors[NL_TERM_NORMAL][c->ansi];
+			break;
+
+		case NL_TERM_COLOR_256:
+			if (c->xterm256 >= 8 && c->xterm256 < 16) {
+				c = nl_term_colors[NL_TERM_NORMAL][c->xterm256 - 8];
+			}
+			break;
+
+		default:
+			// Do nothing for RGB colors
+			break;
+	}
+}
+
+static void set_color_intensity(struct nl_term_state *s)
+{
+	switch(s->intensity) {
+		case NL_TERM_NORMAL:
+			make_color_normal(&s->foreground);
+			break;
+
+		case NL_TERM_INTENSE:
+			make_color_intense(&s->foreground);
+			break;
+
+		case NL_TERM_FAINT:
+			make_color_faint(&s->foreground);
+			break;
+	}
+}
+
+enum color_parse_state {
+	EXPECT_CONTROL,
+	EXPECT_SEMICOLON,
+	EXPECT_2_OR_5,
+	EXPECT_XTERM_256,
+	EXPECT_RED,
+	EXPECT_GREEN,
+	EXPECT_BLUE,
+};
+
+/*
+ * Parses an ANSI color sequence at the start of the given string.  Returns the
+ * number of characters consumed, 0 if the sequence could not be parsed as an
+ * ANSI color (thus no characters consumed), or -1 on error.
+ *
+ * The terminal state will be updated with
+ *
+ * Example valid string prefixes (anything after the m is ignored):
+ *     "\e[1m" -- bold
+ *     "\e[35m" -- purple/magenta foreground
+ *     "\e[38;2;128;128;128m" -- dark gray 24-bit foreground
+ */
+int nl_parse_ansi_color(char *s, struct nl_term_state *state)
+{
+	if (CHECK_NULL(s) || CHECK_NULL(state)) {
+		return -1;
+	}
+
+	struct nl_term_state new_state = *state;
+
+	if (s[0] != 0x1b || s[1] != '[') {
+		// Not the beginning of an ANSI escape sequence.
+		return 0;
+	}
+
+	// TODO: konsole ignores multiple sequential semicolons unless they're within a 256-color or 24-bit-color sequence
+
+	char *ptr = s + 2;
+	char *endptr = NULL;
+	enum color_parse_state ps = EXPECT_CONTROL;
+	enum color_parse_state next_ps = EXPECT_SEMICOLON;
+	enum { FOREGROUND_COLOR, BACKGROUND_COLOR } parse_color = FOREGROUND_COLOR;
+	unsigned long n;
+	while(*ptr) {
+		if (*ptr == 'm') {
+			// End of sequence; update state and return number of characters in sequence
+			*state = new_state;
+			return ptr + 1 - s;
+		}
+
+		switch(ps) {
+			case EXPECT_SEMICOLON:
+				if (*ptr != ';') {
+					// This should have been a semicolon
+					return 0;
+				}
+
+			case EXPECT_CONTROL:
+				next_ps = EXPECT_SEMICOLON;
+
+				n = strtoul(ptr, &endptr, 10);
+				if (endptr == NULL || endptr == ptr) {
+					// Failed to parse a number
+					return 0;
+				}
+				ptr = endptr;
+
+				// I bet that some parsers and the original hardware just use the ones digit as a bit index to set or clear for 1..9 and 21..29
+				switch(n) {
+					case 0:
+						new_state = nl_default_term_state;
+						break;
+
+					case 1:
+						new_state.intensity = NL_TERM_INTENSE;
+						set_color_intensity(&new_state);
+						break;
+
+					case 2:
+						new_state.intensity = NL_TERM_FAINT;
+						set_color_intensity(&new_state);
+						break;
+
+					case 3:
+						new_state.italic = 1;
+						break;
+
+					case 4:
+						new_state.underline = 1;
+						break;
+
+					case 5:
+						new_state.blink = 1;
+						break;
+
+					case 7:
+						new_state.reverse = 1;
+						break;
+
+					case 9:
+						new_state.strikethrough = 1;
+						break;
+
+					case 22:
+						new_state.intensity = NL_TERM_NORMAL;
+						set_color_intensity(&new_state);
+						break;
+
+					case 23:
+						new_state.italic = 0;
+						break;
+
+					case 24:
+						new_state.underline = 0;
+						break;
+
+					case 25:
+						new_state.blink = 0;
+						break;
+
+					case 27:
+						new_state.reverse = 0;
+						break;
+
+					case 29:
+						new_state.strikethrough = 0;
+						break;
+
+					case 38:
+						ps = EXPECT_SEMICOLON;
+						next_ps = EXPECT_2_OR_5;
+						parse_color = FOREGROUND_COLOR;
+						break;
+
+					case 39:
+						new_state.foreground = nl_term_default_foreground;
+						set_color_intensity(&new_state);
+						break;
+
+					case 48:
+						ps = EXPECT_SEMICOLON;
+						next_ps = EXPECT_2_OR_5;
+						parse_color = FOREGROUND_COLOR;
+						break;
+
+					case 49:
+						new_state.background = nl_term_default_background;
+						break;
+
+					default:
+						// Handle standard colors, ignore unsupported values
+						if (n >= 30 && n <= 37) {
+							new_state.foreground = nl_term_standard_colors[new_state.intensity][n - 30];
+						} else if (n >= 40 && n <= 47) {
+							new_state.background = nl_term_standard_colors[NL_TERM_COLOR_DEFAULT][n - 30];
+						}
+
+						break;
+				}
+
+				break;
+
+			case EXPECT_2_OR_5:
+				// If we see 2, expect a 24-bit color.  If we see 5, expect an xterm color.
+				// For other values, xterm ignores them, while konsole resets the color and treats the
+				// value as a standard control code.  Let's do what xterm does.
+				n = strtoul(ptr, &endptr, 10);
+				if (endptr == NULL || endptr == ptr) {
+					// Failed to parse a number
+					return 0;
+				}
+
+				break;
+	}
+
+	// No 'm' was found before the end of the string, so don't consume any characters.
+	return 0;
+}

--- a/src/term.c
+++ b/src/term.c
@@ -18,27 +18,31 @@
  */
 const struct nl_term_color nl_term_default_foreground = NL_TERM_FOREGROUND_INITIALIZER;
 
+#define NL_TERM_BOLD_INITIALIZER { \
+	.r = 234, .g = 234, .b = 234, \
+	.xterm256 = 15, \
+	.ansi = 7, \
+	.color_type = NL_TERM_COLOR_DEFAULT, \
+}
+
+#define NL_TERM_FAINT_INITIALIZER { \
+	.r = 80, .g = 80, .b = 80, \
+	.xterm256 = 7, \
+	.ansi = 7, \
+	.color_type = NL_TERM_COLOR_DEFAULT, \
+}
+
 /*
  * The default bold foreground color if no explicit color is set but color
  * intensity is set to bold.
  */
-const struct nl_term_color nl_term_bold_foreground = {
-	.r = 234, .g = 234, .b = 234,
-	.xterm256 = 15,
-	.ansi = 7,
-	.color_type = NL_TERM_COLOR_DEFAULT,
-};
+const struct nl_term_color nl_term_bold_foreground = NL_TERM_BOLD_INITIALIZER;
 
 /*
  * The default faint foreground color if no explicit color is set, but color
  * intensity is set to faint.
  */
-const struct nl_term_color nl_term_faint_foreground = {
-	.r = 80, .g = 80, .b = 80,
-	.xterm256 = 7,
-	.ansi = 7,
-	.color_type = NL_TERM_COLOR_DEFAULT,
-};
+const struct nl_term_color nl_term_faint_foreground = NL_TERM_FAINT_INITIALIZER;
 
 /*
  * The default background color if no explicit color is set.
@@ -51,44 +55,44 @@ const struct nl_term_color nl_term_default_background = NL_TERM_BACKGROUND_INITI
  */
 const struct nl_term_color nl_term_standard_colors[3][10] = {
 	[ NL_TERM_NORMAL ] = {
-		[0] = {  36,  36,  36, 0, 0 },
-		[1] = { 204,  66,  66, 1, 1 },
-		[2] = { 104, 154,  51, 2, 2 },
-		[3] = { 196, 165,  42, 3, 3 },
-		[4] = {  61, 107, 164, 4, 4 },
-		[5] = { 116,  80, 123, 5, 5 },
-		[6] = {  63, 154, 154, 6, 6 },
-		[7] = { 158, 158, 158, 7, 7 },
+		[0] = {  36,  36,  36, 0, 0, NL_TERM_COLOR_STANDARD },
+		[1] = { 204,  66,  66, 1, 1, NL_TERM_COLOR_STANDARD },
+		[2] = { 104, 154,  51, 2, 2, NL_TERM_COLOR_STANDARD },
+		[3] = { 196, 165,  42, 3, 3, NL_TERM_COLOR_STANDARD },
+		[4] = {  61, 107, 164, 4, 4, NL_TERM_COLOR_STANDARD },
+		[5] = { 116,  80, 123, 5, 5, NL_TERM_COLOR_STANDARD },
+		[6] = {  63, 154, 154, 6, 6, NL_TERM_COLOR_STANDARD },
+		[7] = { 158, 158, 158, 7, 7, NL_TERM_COLOR_STANDARD },
 
 		// Default colors (foreground, background)
-		[8] = nl_term_default_foreground,
-		[9] = nl_term_default_background,
+		[8] = NL_TERM_FOREGROUND_INITIALIZER,
+		[9] = NL_TERM_BACKGROUND_INITIALIZER,
 	},
 	[ NL_TERM_BOLD ] = {
-		[0] = {  70,  70,  70,  8, 0 },
-		[1] = { 225,  70,  70,  9, 1 },
-		[2] = { 138, 196,  81, 10, 2 },
-		[3] = { 205, 189,  83, 11, 3 },
-		[4] = {  85, 146, 207, 12, 4 },
-		[5] = { 173, 115, 167, 13, 5 },
-		[6] = {  78, 190, 190, 14, 6 },
-		[7] = { 234, 234, 234, 15, 7 },
+		[0] = {  70,  70,  70,  8, 0, NL_TERM_COLOR_STANDARD },
+		[1] = { 225,  70,  70,  9, 1, NL_TERM_COLOR_STANDARD },
+		[2] = { 138, 196,  81, 10, 2, NL_TERM_COLOR_STANDARD },
+		[3] = { 205, 189,  83, 11, 3, NL_TERM_COLOR_STANDARD },
+		[4] = {  85, 146, 207, 12, 4, NL_TERM_COLOR_STANDARD },
+		[5] = { 173, 115, 167, 13, 5, NL_TERM_COLOR_STANDARD },
+		[6] = {  78, 190, 190, 14, 6, NL_TERM_COLOR_STANDARD },
+		[7] = { 234, 234, 234, 15, 7, NL_TERM_COLOR_STANDARD },
 
-		[8] = nl_term_bold_foreground,
-		[9] = nl_term_default_background,
+		[8] = NL_TERM_BOLD_INITIALIZER,
+		[9] = NL_TERM_BACKGROUND_INITIALIZER,
 	},
 	[ NL_TERM_FAINT ] = {
-		[0] = {  24,  24,  24, 0, 0 },
-		[1] = { 140,  41,  41, 1, 1 },
-		[2] = {  70, 100,  41, 2, 2 },
-		[3] = { 100,  87,  40, 3, 3 },
-		[4] = {  39,  78, 125, 4, 4 },
-		[5] = {  95,  65, 100, 5, 5 },
-		[6] = {  35,  80,  80, 6, 6 },
-		[7] = {  80,  80,  80, 7, 7 },
+		[0] = {  24,  24,  24, 0, 0, NL_TERM_COLOR_STANDARD },
+		[1] = { 140,  41,  41, 1, 1, NL_TERM_COLOR_STANDARD },
+		[2] = {  70, 100,  41, 2, 2, NL_TERM_COLOR_STANDARD },
+		[3] = { 100,  87,  40, 3, 3, NL_TERM_COLOR_STANDARD },
+		[4] = {  39,  78, 125, 4, 4, NL_TERM_COLOR_STANDARD },
+		[5] = {  95,  65, 100, 5, 5, NL_TERM_COLOR_STANDARD },
+		[6] = {  35,  80,  80, 6, 6, NL_TERM_COLOR_STANDARD },
+		[7] = {  80,  80,  80, 7, 7, NL_TERM_COLOR_STANDARD },
 
-		[8] = nl_term_bold_foreground,
-		[9] = nl_term_default_background,
+		[8] = NL_TERM_BOLD_INITIALIZER,
+		[9] = NL_TERM_BACKGROUND_INITIALIZER,
 	},
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,5 +49,8 @@ target_link_libraries(stream_test nlutils)
 add_executable(debug_test debug_test.c)
 target_link_libraries(debug_test nlutils)
 
+add_executable(term_test term_test.c)
+target_link_libraries(term_test nlutils)
+
 file(COPY firmware tests.sh
 	DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/term_test.c
+++ b/tests/term_test.c
@@ -1,0 +1,210 @@
+/*
+ * Tests for terminal-related functions.
+ * Copyright (C)2023 Mike Bourgeous.  Licensed under AGPLv3.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "nlutils.h"
+
+struct parse_color_test {
+	char *desc;
+	char *input;
+	int expected_return;
+	struct nl_term_state init_state;
+	struct nl_term_state expected_state;
+};
+
+static const struct nl_term_state all_on = {
+	.fg = { 253, 254, 255, 0, 0, NL_TERM_COLOR_RGB },
+	.bg = { 5, 4, 3, 0, 0, NL_TERM_COLOR_RGB },
+	.intensity = NL_TERM_INTENSE,
+	.italic = 1,
+	.underline = 1,
+	.blink = 1,
+	.reverse = 1,
+	.strikethrough = 1,
+};
+
+static struct parse_color_test color_tests[] = {
+	{
+		.desc = "Empty valid sequence, no change to state (from zero state)",
+		.input = "\e[m",
+		.expected_return = 3,
+	},
+	{
+		.desc = "Empty valid sequence, no change to state (from default state)",
+		.input = "\e[m",
+		.expected_return = 3,
+		.init_state = NL_TERM_STATE_INITIALIZER,
+		.expected_state = NL_TERM_STATE_INITIALIZER,
+	},
+	{
+		.desc = "Empty valid sequence, no change to state (from modified state)",
+		.input = "\e[m",
+		.expected_return = 3,
+		.init_state = all_on,
+		.expected_state = all_on,
+	},
+	{
+		.desc = "Invalid sequence does not alter state",
+		.input = "\e[1;3;4;5;7;9;38;5;253;254;255;48;5;5;4;3m",
+		.expected_return = 42,
+		.init_state = all_on,
+		.expected_state = all_on,
+	},
+	{
+		.desc = "Reset to default",
+		.input = "\e[0m",
+		.expected_return = 4,
+		.init_state = all_on,
+		.expected_state = NL_TERM_STATE_INITIALIZER,
+	},
+	{
+		.desc = "Generate all-on state (RGB colors, turn on all flags)",
+		.input = "\e[1;3;4;5;7;9;38;5;253;254;255;48;5;5;4;3m",
+		.expected_return = 42,
+		.init_state = all_on,
+		.expected_state = NL_TERM_STATE_INITIALIZER,
+	},
+};
+
+#define COMPARE_FIELD(ret, msg, format, field, actual, expected) do { \
+	if ((actual)->field != (expected)->field) { \
+		ERROR_OUT("\t\t%s %s->%s = " format " but %s->%s = " format "\n", \
+				(msg), #actual, #field, (actual)->field, #expected, #field, (expected)->field); \
+		ret++; \
+	} \
+} while (0);
+
+static int compare_term_color(char *msg, struct nl_term_color *c, struct nl_term_color *expected)
+{
+	int ret = 0;
+
+	if (!memcmp(c, expected, sizeof(struct nl_term_color))) {
+		DEBUG_OUT("%s colors match\n", msg);
+		return 0;
+	}
+
+	ERROR_OUT("%s colors do not match:\n", msg);
+
+	// Wish there was a way to iterate over a struct in C
+	COMPARE_FIELD(ret, msg, "%u", r, c, expected);
+	COMPARE_FIELD(ret, msg, "%u", g, c, expected);
+	COMPARE_FIELD(ret, msg, "%u", b, c, expected);
+	COMPARE_FIELD(ret, msg, "%u", xterm256, c, expected);
+	COMPARE_FIELD(ret, msg, "%u", ansi, c, expected);
+	COMPARE_FIELD(ret, msg, "%d", color_type, c, expected);
+
+	return ret;
+}
+
+static int compare_term_state(char *test_name, struct nl_term_state *s, struct nl_term_state *expected)
+{
+	int ret = 0;
+
+	if (s == NULL && expected != NULL) {
+		ERROR_OUT("Terminal state is NULL but expected is not NULL.\n");
+		return -1;
+	}
+	if (s != NULL && expected == NULL) {
+		ERROR_OUT("Terminal state is not NULL but expected is NULL.\n");
+		return 1;
+	}
+	if (s == expected) {
+		if (s != NULL) {
+			ERROR_OUT("Do not pass the same non-NULL pointer for received state and expected state.\n");
+			return -1;
+		}
+
+		DEBUG_OUT("Both received and expected state pointers are NULL.\n");
+		return 0;
+	}
+
+	if (!memcmp(s, expected, sizeof(struct nl_term_state))) {
+		DEBUG_OUT("Terminal state values match.\n");
+		return 0;
+	}
+
+	ERROR_OUT("\tTerminal state does not match expected state for test %s:\n", test_name);
+
+	if (compare_term_color("\tforeground", &s->fg, &expected->fg)) {
+		ret++;
+	}
+	if (compare_term_color("\tbackground", &s->bg, &expected->bg)) {
+		ret++;
+	}
+
+	COMPARE_FIELD(ret, test_name, "%d", intensity, s, expected);
+	COMPARE_FIELD(ret, test_name, "%u", italic, s, expected);
+	COMPARE_FIELD(ret, test_name, "%u", underline, s, expected);
+	COMPARE_FIELD(ret, test_name, "%u", blink, s, expected);
+	COMPARE_FIELD(ret, test_name, "%u", reverse, s, expected);
+	COMPARE_FIELD(ret, test_name, "%u", strikethrough, s, expected);
+
+	return ret;
+}
+
+int test_nl_term_parse_ansi_color(void)
+{
+	struct nl_term_state state = NL_TERM_STATE_INITIALIZER;
+	int failures = 0;
+	int result;
+
+	INFO_OUT("Testing nl_term_parse_ansi_color()\n");
+
+	result = nl_term_parse_ansi_color(NULL, NULL);
+	if (result != -1) {
+		ERROR_OUT("Expected -1 for null input and null state\n");
+		failures += 1;
+	}
+
+	result = nl_term_parse_ansi_color(NULL, &state);
+	if (result != -1) {
+		ERROR_OUT("Expected -1 for null input and valid state\n");
+		failures += 1;
+	}
+	
+	result = nl_term_parse_ansi_color("\e[0m", NULL);
+	if (result != -1) {
+		ERROR_OUT("Expected -1 for valid input and null state\n");
+		failures += 1;
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(color_tests); i++) {
+		struct parse_color_test *t = &color_tests[i];
+
+		DEBUG_OUT("\tColor parsing test: %s\n", t->desc);
+		state = t->init_state;
+
+		result = nl_term_parse_ansi_color(t->input, &state);
+		if (result != t->expected_return) {
+			ERROR_OUT("\tExpected return value of %d, got %d for test %s\n", t->expected_return, result, t->desc);
+			failures += 1;
+		}
+
+		if (compare_term_state(t->desc, &state, &t->expected_state)) {
+			failures += 1;
+		}
+	}
+
+	return failures;
+}
+
+int main(void)
+{
+	int failures = 0;
+
+	INFO_OUT("Testing terminal functions\n");
+
+	failures += test_nl_term_parse_ansi_color();
+
+	if (failures) {
+		ERROR_OUT("%d terminal function tests failed\n", failures);
+	} else {
+		INFO_OUT("All terminal function tests succeeded\n");
+	}
+
+	return !!failures;
+}

--- a/tests/term_test.c
+++ b/tests/term_test.c
@@ -80,14 +80,9 @@ static struct parse_color_test color_tests[] = {
 
 static int compare_term_color(char *msg, struct nl_term_color *c, struct nl_term_color *expected)
 {
-	if (!memcmp(c, expected, sizeof(struct nl_term_color))) {
-		DEBUG_OUT("%s colors match\n", msg);
-		return 0;
-	}
+	DEBUG_OUT("\e[36mSize of color is \e[1m%zu\e[0m\n", sizeof(struct nl_term_color));
 
-	int ret = 1;
-
-	ERROR_OUT("%s colors do not match:\n", msg);
+	int ret = 0;
 
 	// Wish there was a way to iterate over a struct in C
 	COMPARE_FIELD(ret, msg, "%u", r, c, expected);
@@ -102,6 +97,8 @@ static int compare_term_color(char *msg, struct nl_term_color *c, struct nl_term
 
 static int compare_term_state(char *test_name, struct nl_term_state *s, struct nl_term_state *expected)
 {
+	DEBUG_OUT("\e[36mSize of state is \e[1m%zu\e[0m\n", sizeof(struct nl_term_state));
+
 	if (s == NULL && expected != NULL) {
 		ERROR_OUT("Terminal state is NULL but expected is not NULL for %s.\n", test_name);
 		return -1;
@@ -120,14 +117,7 @@ static int compare_term_state(char *test_name, struct nl_term_state *s, struct n
 		return 0;
 	}
 
-	if (!memcmp(s, expected, sizeof(struct nl_term_state))) {
-		DEBUG_OUT("Terminal state values match for %s.\n", test_name);
-		return 0;
-	}
-
-	int ret = 1;
-
-	ERROR_OUT("\tTerminal state does not match expected state for test %s:\n", test_name);
+	int ret = 0;
 
 	if (compare_term_color("\tforeground", &s->fg, &expected->fg)) {
 		ret++;

--- a/tests/term_test.c
+++ b/tests/term_test.c
@@ -50,7 +50,7 @@ static struct parse_color_test color_tests[] = {
 	{
 		.desc = "Invalid sequence does not alter state",
 		.input = "\e[1;3;4;5;7;9;38;5;253;254;255;48;5;5;4;3m",
-		.expected_return = 42,
+		.expected_return = 0,
 		.init_state = all_on,
 		.expected_state = all_on,
 	},

--- a/tests/term_test.c
+++ b/tests/term_test.c
@@ -16,16 +16,16 @@ struct parse_color_test {
 	struct nl_term_state expected_state;
 };
 
-static const struct nl_term_state all_on = {
-	.fg = { 253, 254, 255, 0, 0, NL_TERM_COLOR_RGB },
-	.bg = { 5, 4, 3, 0, 0, NL_TERM_COLOR_RGB },
-	.intensity = NL_TERM_INTENSE,
-	.italic = 1,
-	.underline = 1,
-	.blink = 1,
-	.reverse = 1,
-	.strikethrough = 1,
-};
+#define ALL_ON_INITIALIZER { \
+	.fg = { 253, 254, 255, 0, 0, NL_TERM_COLOR_RGB }, \
+	.bg = { 5, 4, 3, 0, 0, NL_TERM_COLOR_RGB }, \
+	.intensity = NL_TERM_INTENSE, \
+	.italic = 1, \
+	.underline = 1, \
+	.blink = 1, \
+	.reverse = 1, \
+	.strikethrough = 1, \
+}
 
 static struct parse_color_test color_tests[] = {
 	{
@@ -44,21 +44,21 @@ static struct parse_color_test color_tests[] = {
 		.desc = "Empty valid sequence, no change to state (from modified state)",
 		.input = "\e[m",
 		.expected_return = 3,
-		.init_state = all_on,
-		.expected_state = all_on,
+		.init_state = ALL_ON_INITIALIZER,
+		.expected_state = ALL_ON_INITIALIZER,
 	},
 	{
 		.desc = "Invalid sequence does not alter state",
 		.input = "\e[1;3;4;5;7;9;38;2;253;254;255;48;2;5;4;3K",
 		.expected_return = 0,
-		.init_state = all_on,
-		.expected_state = all_on,
+		.init_state = ALL_ON_INITIALIZER,
+		.expected_state = ALL_ON_INITIALIZER,
 	},
 	{
 		.desc = "Reset to default",
 		.input = "\e[0m",
 		.expected_return = 4,
-		.init_state = all_on,
+		.init_state = ALL_ON_INITIALIZER,
 		.expected_state = NL_TERM_STATE_INITIALIZER,
 	},
 	{
@@ -66,7 +66,7 @@ static struct parse_color_test color_tests[] = {
 		.input = "\e[1;3;4;5;7;9;38;2;253;254;255;48;2;5;4;3m",
 		.expected_return = 42,
 		.init_state = NL_TERM_STATE_INITIALIZER,
-		.expected_state = all_on,
+		.expected_state = ALL_ON_INITIALIZER,
 	},
 };
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -326,3 +326,8 @@ runtest false 'Extract version 3 firmware that is expected to fail' \
 headline "Testing debugging-related functions"
 runtest true 'Debugging-related function tests' \
 	./debug_test
+
+# Test terminal-related functions
+headline "Testing terminal-related functions (e.g. color escape parsing)"
+runtest true 'Terminal-related function tests' \
+	./term_test

--- a/tests/thread_test.c
+++ b/tests/thread_test.c
@@ -422,7 +422,7 @@ int main()
 
 	for(i = 0; i < NUM_THREADS; i++) {
 		// TODO: Test SCHED_FIFO if running with sufficient capabilities
-		DEBUG_OUT("Setting thread %zu (%s) scheduler to OTHER\n", i, buf);
+		DEBUG_OUT("Setting thread %zu scheduler to OTHER\n", i);
 
 		ret = nl_set_thread_priority(info[i], SCHED_OTHER, 0);
 		if(ret) {

--- a/tests/variant/clamp_test.c
+++ b/tests/variant/clamp_test.c
@@ -91,7 +91,7 @@ int main()
 	check_float(FLT_MAX, -INFINITY, INFINITY, FLT_MAX);
 
 	// test reversed ranges
-	check_float(0, INT_MAX, INT_MIN, INT_MAX);
+	check_float(0, 1 << 15, -(1 << 15), 1 << 15); // was INT_MIN and INT_MAX, but clang complained about values changing when converted to float
 	check_float(0, 3, 1, 3);
 	check_float(1, 3, 1, 3);
 	check_float(2, 3, 1, 3);


### PR DESCRIPTION
This PR introduces `nl_term_parse_ansi_color()`, which parses an ANSI color escape sequence starting with `\e[` and ending with `m`.

This function will be used in my non-public visualization code to implement syntax-highlighted code display and/or other text features.